### PR TITLE
Add constraint for dependency towards python-intervals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ schema>=0.7.1
 kitchen>=1.2.6
 psycopg2-binary
 networkx>=2.3
-python-intervals
+python-intervals<2.0.0
 rdflib>=4.2.2
 requests>=2.22.0
 unidecode>=1.1.1


### PR DESCRIPTION
Hello,

I see that you're relying on `python-intervals`. I suggest to add a dependency constraint (e.g. `<2.0.0`) since version 2.0.0 will be released soon, and contains backward incompatible changes (e.g. `.is_empty()` method will be replaced by `.empty` property).